### PR TITLE
PR Clone: Add zoomgov.com domain to manafest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,11 @@
         "https://zoom.us/j/*",
         "https://*.zoom.us/j/*",
         "https://zoom.us/s/*",
-        "https://*.zoom.us/s/*"
+        "https://*.zoom.us/s/*",
+        "https://zoomgov.com/j/*",
+        "https://*.zoomgov.com/j/*",
+        "https://zoomgov.com/s/*",
+        "https://*.zoomgov.com/s/*"
       ],
       "js": [
         "content.js"


### PR DESCRIPTION
Replicating PR from  https://github.com/seanstar12/zoom-close/pull/13
> Not sure if /s/ is a thing on zoomgov.com but adding it to match the existing pattern.

~ @gileswells