### PR TITLE
postattendee page is showing up on subdomains now

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,7 @@
       "run_at": "document_start",
       "matches": [
         "https://zoom.us/postattendee",
+        "https://*.zoom.us/postattendee",
         "https://zoom.us/j/*",
         "https://*.zoom.us/j/*",
         "https://zoom.us/s/*",


### PR DESCRIPTION
If you're willing to add the `hacktoberfest-accepted` label to this if/when you merge I'd appreciate it.